### PR TITLE
Fix static using statements

### DIFF
--- a/src/PluginMerge/Creator/BaseCreator.cs
+++ b/src/PluginMerge/Creator/BaseCreator.cs
@@ -153,11 +153,19 @@ public class BaseCreator
     {
         Writer.WriteUsings(_files
                            .SelectMany(f => f.UsingStatements)
-                           .Distinct()
-                           .Where(u => !_settings.Merge.IgnoreNameSpaces.Any(u.StartsWith)));
-        
+                           .DistinctBy(u => u.ToString())
+                           .Where(u => !_settings.Merge.IgnoreNameSpaces.Any(u.Name.ToString().StartsWith))
+                           .Select(u => u.ToString()));
+
+        Writer.WriteUsings(_files
+                           .SelectMany(f => f.UsingStatics)
+                           .DistinctBy(u => u.ToString())
+                           .Where(u => !_settings.Merge.IgnoreNameSpaces.Any(u.Name.ToString().StartsWith))
+                           .Select(u => u.ToString()));
+
         Writer.WriteUsings(_files
                            .SelectMany(f => f.UsingAliases)
+                           .Select(u => u.ToString())
                            .Distinct());
     }
 

--- a/src/PluginMerge/Creator/CodeWriter.cs
+++ b/src/PluginMerge/Creator/CodeWriter.cs
@@ -62,12 +62,12 @@ public class CodeWriter
     /// <param name="usings"></param>
     public void WriteUsings(IEnumerable<string> usings)
     {
+        if (!usings.Any())
+            return;
+
         foreach (string @using in usings.OrderBy(u => u))
         {
-            _writer.Append("using ");
-            _writer.Append(@using);
-            _writer.Append(';');
-            _writer.AppendLine();
+            _writer.AppendLine(@using);
         }
 
         WriteLine();

--- a/src/PluginMerge/Merge/FileHandler.cs
+++ b/src/PluginMerge/Merge/FileHandler.cs
@@ -27,15 +27,20 @@ public class FileHandler
     public PluginData PluginData { get; private set; }
         
     /// <summary>
-    /// Using statements in the code file
+    /// Basic using statements in the code file
     /// </summary>
-    public List<string> UsingStatements { get; } = new();
-    
+    public List<UsingDirectiveSyntax> UsingStatements { get; } = new();
+
     /// <summary>
-    /// Using statements in the code file
+    /// Static using statements in the code file
     /// </summary>
-    public List<string> UsingAliases { get; } = new();
-    
+    public List<UsingDirectiveSyntax> UsingStatics { get; } = new();
+
+    /// <summary>
+    /// Alias using statements in the code file
+    /// </summary>
+    public List<UsingDirectiveSyntax> UsingAliases { get; } = new();
+
     /// <summary>
     /// Using statements in the code file
     /// </summary>
@@ -155,16 +160,19 @@ public class FileHandler
         _logger.LogDebug("Start processing usings file at path: {Path}", RegionName);
         foreach (UsingDirectiveSyntax @using in root.Usings)
         {
-            string name = @using.Name.ToString();
-            if (!name.Equals(settings.Namespace))
+            if (!@using.Name.ToString().Equals(settings.Namespace))
             {
-                if (@using.Alias == null)
+                if (@using.Alias != null)
                 {
-                    UsingStatements.Add(name);
+                    UsingAliases.Add(@using);
+                }
+                else if (@using.StaticKeyword != default)
+                {
+                    UsingStatics.Add(@using);
                 }
                 else
                 {
-                    UsingAliases.Add($"{@using.Alias.ToString()} {name}");
+                    UsingStatements.Add(@using);
                 }
             }
         }


### PR DESCRIPTION
Fixes #8.

Normal using statements are shown first, then statics, then aliases. No extra newlines inserted if a group is empty. Example:

```cs
using System;
using System.Collections;
using System.Collections.Generic;
using System.Linq;
using System.Text;

using static IOEntity;
using static WireTool;

using CustomKillCallback = System.Action<UnityEngine.Component>;
using CustomSpawnCallback = System.Func<UnityEngine.Vector3, UnityEngine.Quaternion, Newtonsoft.Json.Linq.JObject, UnityEngine.Component>;
```