### PR TITLE
Fix FileOrder not being applied correctly between plugin and data files

### DIFF
--- a/src/PluginMerge/Creator/FileCreator.cs
+++ b/src/PluginMerge/Creator/FileCreator.cs
@@ -83,8 +83,14 @@ public class FileCreator
         WriteNamespaceUsings();
         if (IsMergeFrameworkMode) _writer.WriteFramework();
         StartPluginClass();
-        WritePluginFiles();
-        if (IsPluginMode || IsFrameworkMode) WriteDataFiles();
+        if (IsPluginMode || IsFrameworkMode)
+        {
+            WritePluginAndDataFiles();
+        }
+        else
+        {
+            WritePluginFiles();
+        }
         EndPluginClass();
         if (IsMergeFrameworkMode) WriteDataFiles();
         WriteFrameworks();
@@ -357,6 +363,21 @@ public class FileCreator
         foreach (FileHandler file in _dataFiles)
         {
             _logger.LogDebug("Writing data file: {Path}", file.FilePath);
+            Write(file);
+        }
+    }
+
+    /// <summary>
+    /// Writes the plugin and data files together in the order specified by the Order property
+    /// </summary>
+    private void WritePluginAndDataFiles()
+    {
+        List<FileHandler> orderedFiles = _pluginFiles.Concat(_dataFiles)
+                                                     .OrderBy(f => f.Order)
+                                                     .ToList();
+        foreach (FileHandler file in orderedFiles)
+        {
+            _logger.LogDebug("Writing ordered file: {Path}", file.FilePath);
             Write(file);
         }
     }

--- a/tools/Local Install.bat
+++ b/tools/Local Install.bat
@@ -1,5 +1,5 @@
 cd ../src/PluginMerge
 
 dotnet tool uninstall -g MJSU.Plugin.Merge
-dotnet build --configuration Release /p:Version=1.0.5
-dotnet tool install --global --add-source ./bin/nupkg MJSU.Plugin.Merge --version 1.0.5
+dotnet build --configuration Release /p:Version=1.0.15
+dotnet tool install --global --add-source ./bin/nupkg MJSU.Plugin.Merge --version 1.0.15


### PR DESCRIPTION
Files are correctly ordered with the `FileOrder` directive in `MergeHandler`. However, they are being split into three categories of files in the `FileCreator`: `_pluginFiles`, `_dataFiles` and `_frameworks`. These category of files are then written in separate loops, breaking the original order specified. 

In `PluginMode` and `FrameworkMode`, plugin and data files are always written together in the same class. However, since they run in different loops, the order originally specified is broken.

To fix this, when in `PluginMode` or `FrameworkMode`, I write plugin and data files together, in the `Order` they are specified.

Fixes #30 